### PR TITLE
bump pngquant-bin to 5.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
 		"is-png": "^1.0.0",
 		"is-lambda": "^1.0.1",
 		"is-stream": "^1.1.0",
-		"pngquant-bin": "5.0.1"
+		"pngquant-bin": "^5.0.2"
 	},
 	"devDependencies": {
 		"ava": "*",


### PR DESCRIPTION
5.0.2 is a security patch: https://github.com/imagemin/pngquant-bin/compare/v5.0.1...v5.0.2